### PR TITLE
Updated PurchaseOrder to support proper name for BrandingThemeID

### DIFF
--- a/lib/xeroizer/models/purchase_order.rb
+++ b/lib/xeroizer/models/purchase_order.rb
@@ -28,7 +28,7 @@ module Xeroizer
       string  :type
       string  :currency_rate
       string  :currency_code
-      string  :branding_theme_id 
+      string  :branding_theme_id, :api_name => 'BrandingThemeID' 
       string  :status 
       string  :line_amount_types
       string  :sub_total


### PR DESCRIPTION
Xero APO doesn't recognise BrandingThemeId, so overriding the api_name to use proper casing.
